### PR TITLE
feat: add head injection and static asset serving hooks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -200,6 +200,63 @@ When the `:get` handler is a Var (e.g. `#'dashboard-page`), it's automatically
 added to the route's watches. This means redefining the function at the REPL
 triggers an instant live reload for all connected tabs — no page refresh needed.
 
+## Assets and `<head>` injection
+
+Hyper doesn’t ship with an asset pipeline (Tailwind, Vite, etc.), but it *does*
+provide a couple small hooks so apps can easily:
+
+- serve precompiled static assets (CSS/JS/images)
+- inject tags into the HTML `<head>` (stylesheets, scripts, meta tags)
+
+### Static assets
+
+Enable static serving when you create your handler:
+
+```clojure
+(def handler
+  (h/create-handler
+    #'routes
+    :static-resources "public"))
+```
+
+Put files under `resources/public/` and they’ll be available by URL:
+
+- `resources/public/app.css` → `GET /app.css`
+- `resources/public/favicon.ico` → `GET /favicon.ico`
+
+For filesystem-based serving (useful in dev):
+
+```clojure
+(def handler
+  (h/create-handler
+    #'routes
+    :static-dir "public"))
+```
+
+You can also pass multiple directories (first match wins):
+
+```clojure
+(def handler
+  (h/create-handler
+    #'routes
+    :static-dir ["public" "target/public"]))
+```
+
+### Injecting into `<head>`
+
+Pass `:head` as either hiccup, or a function `(fn [req] ...)` that returns hiccup:
+
+```clojure
+(def handler
+  (h/create-handler
+    #'routes
+    :static-resources "public"
+    :head [[:link {:rel "stylesheet" :href "/app.css"}]
+           [:script {:defer true :src "/app.js"}] ]))
+```
+
+This is typically how you’d include your compiled Tailwind stylesheet.
+
 ## Testing
 
 Tests are run with [Kaocha](https://github.com/lambdaisland/kaocha) via the

--- a/resources/public/hyper-test-static.txt
+++ b/resources/public/hyper-test-static.txt
@@ -1,0 +1,1 @@
+static-ok

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -238,9 +238,12 @@
            without restarting the server — ideal for REPL-driven development.
 
    Options (keyword arguments):
-   - :app-state  — Atom for application state (default: fresh atom)
-   - :executor   — java.util.concurrent.ExecutorService for render dispatch
-                   (default: virtual-thread-per-task executor)
+   - :app-state         — Atom for application state (default: fresh atom)
+   - :executor          — java.util.concurrent.ExecutorService for render dispatch
+                          (default: virtual-thread-per-task executor)
+   - :head              — Hiccup nodes appended to the HTML <head>, or (fn [req] ...) -> hiccup
+   - :static-resources  — Classpath resource root(s) to serve as static assets
+   - :static-dir        — Filesystem directory (or directories) to serve as static assets
 
    Example:
      (def routes
@@ -255,14 +258,23 @@
      ;; Live-reloading routes (pass the Var)
      (def handler (create-handler #'routes))
 
+     ;; Inject a stylesheet (e.g. Tailwind output)
+     (def handler
+       (create-handler routes
+                       :static-resources \"public\"
+                       :head [[:link {:rel \"stylesheet\" :href \"/app.css\"}]]))
+
      ;; Custom executor
      (def handler (create-handler routes :executor my-executor))
 
      (def server (start! handler {:port 3000}))"
-  [routes & {:keys [app-state executor]
+  [routes & {:keys [app-state executor head static-resources static-dir]
              :or   {app-state (atom (state/init-state))
                     executor  (java.util.concurrent.Executors/newVirtualThreadPerTaskExecutor)}}]
-  (server/create-handler routes app-state executor #'*request*))
+  (server/create-handler routes app-state executor #'*request*
+                         {:head head
+                          :static-resources static-resources
+                          :static-dir static-dir}))
 
 (defn start!
   "Start the hyper application server.


### PR DESCRIPTION
Expose small opt-in hooks to make it easy for Hyper apps to ship compiled assets (e.g. Tailwind output) without adding an asset pipeline to the framework.

- Add :head / :head-fn options to inject hiccup into the HTML <head>
- Add :static-resources and :static-dir options to serve static assets (with content-type + not-modified support) from create-handler
- Document the new hooks and expand server tests to cover them