### PR TITLE
Add hot-reload support for :head option via Var

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -438,6 +438,9 @@ and the `<title>` are all kept in sync reactively.
            [:script {:defer true :src "/app.js"}] ]))
 ```
 
+Pass `:head` as a Var (`#'my-head`) to enable live-reloading — when you
+redefine it at the REPL, all connected tabs automatically update their `<head>`.
+
 This is typically how you’d include your compiled Tailwind stylesheet.
 
 ## Brotli compression
@@ -515,5 +518,7 @@ The E2E suite covers:
   cursors propagate to exactly the right scope
 - **Title live reload** — redefining the routes Var updates `document.title`
   via SSE without a page refresh
+- **Head live reload** — redefining the `:head` Var hot-swaps `<head>` content
+  via SSE
 - **Content live reload** — redefining the routes Var with new inline handler
   functions hot-swaps the page content via SSE

--- a/src/hyper/routes.clj
+++ b/src/hyper/routes.clj
@@ -76,6 +76,7 @@
 
    - If :head is a function, it is called with the Ring request (already enriched
      with Hyper context) and should return hiccup nodes.
+   - If :head is a Var, dereferences and calls the resulting function with req.
    - Otherwise, :head is treated as hiccup and used as-is.
 
    Intended for injecting stylesheets/scripts (e.g. Tailwind output CSS) without
@@ -83,5 +84,6 @@
   [head req]
   (cond
     (fn? head)   (head req)
+    (var? head)  (resolve-head @head req)
     (some? head) head
     :else        nil))

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -210,6 +210,11 @@
                                           (when-let [routes-source (get @app-state* :routes-source)]
                                             (when (var? routes-source)
                                               (watch/watch-source! app-state* tab-id trigger-render! routes-source)))
+                                          ;; Auto-watch the head Var so head content changes
+                                          ;; trigger re-renders for all connected tabs
+                                          (when-let [head (get @app-state* :head)]
+                                            (when (var? head)
+                                              (watch/watch-source! app-state* tab-id trigger-render! head)))
                                           ;; Set up route-level watches (:watches + Var :get handlers)
                                           (watch/setup-route-watches! app-state* tab-id trigger-render!)))
 
@@ -511,10 +516,11 @@
          ;; Store the routes source (Var or value) so title resolution can
          ;; always read the latest route metadata, even between router rebuilds.
          ;; Store global :watches so find-route-watches can prepend them to
-         ;; every page route's watch list.
+         ;; every page route's watch list. Auto-watch :head if it's a Var.
          _                                        (swap! app-state* assoc
                                                          :routes-source routes
-                                                         :global-watches (vec watches)
+                                                         :global-watches (cond-> (vec watches)
+                                                                           (var? head) (conj head))
                                                          :head head)
          initial-routes                           (if (var? routes) @routes routes)
          initial-handler                          (build-ring-handler initial-routes app-state* page-wrapper system-routes)

--- a/test/hyper/e2e_test.clj
+++ b/test/hyper/e2e_test.clj
@@ -101,6 +101,11 @@
 
 (def ^:dynamic *test-routes* (default-routes))
 
+;; Head var for hot-reload testing
+(defn- test-head-var
+  [_]
+  [:style "v1"])
+
 ;; ---------------------------------------------------------------------------
 ;; Server lifecycle
 ;; ---------------------------------------------------------------------------
@@ -112,7 +117,7 @@
 
 (defn start-test-server! []
   (reset! test-state* (atom (state/init-state)))
-  (let [handler (h/create-handler #'*test-routes* :app-state @test-state*)]
+  (let [handler (h/create-handler #'*test-routes* :app-state @test-state* :head #'test-head-var)]
     (reset! test-server (h/start! handler {:port test-port}))))
 
 (defn stop-test-server! []
@@ -230,9 +235,9 @@
 
 (use-fixtures :each
   (fn [f]
-    ;; Reset routes and app state before each test, preserving
-    ;; infrastructure keys (:routes-source, etc.)
-    ;; that create-handler stored in the app-state atom.
+     ;; Reset routes and app state before each test, preserving
+     ;; infrastructure keys (:routes-source, :head, etc.)
+     ;; that create-handler stored in the app-state atom.
     (alter-var-root #'*test-routes* (constantly (default-routes)))
     (when @test-state*
       (swap! @test-state*
@@ -240,6 +245,7 @@
                (merge (state/init-state)
                       (select-keys old-state
                                    [:routes-source
+                                    :head
                                     :router :routes])))))
     (f)))
 
@@ -573,6 +579,38 @@
           (is (= "Live Reloaded!" (w/text-content "h1")))
           (is (= "This content was hot-swapped"
                  (w/text-content "#reloaded-marker")))))
+
+      (finally
+        (close-browser! browser-info)))))
+
+(deftest ^:e2e head-redef-test
+  (let [browser-info (launch-browser)
+        ctx          (new-context browser-info)
+        page         (new-page ctx)]
+    (try
+      (w/with-page page
+        (w/navigate (str base-url "/"))
+        (wait-for-sse)
+
+        ;; Verify initial head content
+        (testing "Initial head content present"
+          (Thread/sleep 500)
+          (is (= "v1" (w/text-content "style"))))
+
+        ;; Redefine head Var
+        (testing "Head updates after head Var is redefined"
+          (alter-var-root #'test-head-var (constantly (fn [_] [:style "v2"])))
+          (Thread/sleep 500)
+
+          ;; Wait for SSE to re-render
+          (let [deadline (+ (System/currentTimeMillis) 5000)]
+            (loop []
+              (let [content (w/text-content "style")]
+                (when (and (not= "v2" content)
+                           (< (System/currentTimeMillis) deadline))
+                  (Thread/sleep 100)
+                  (recur)))))
+          (is (= "v2" (w/text-content "style")))))
 
       (finally
         (close-browser! browser-info)))))

--- a/test/hyper/routes_test.clj
+++ b/test/hyper/routes_test.clj
@@ -159,4 +159,10 @@
 
   (testing "static value returned as-is"
     (is (= [:style "body{}"]
-           (routes/resolve-head [:style "body{}"] {})))))
+           (routes/resolve-head [:style "body{}"] {}))))
+
+  (testing "Var is dereferenced and called with request"
+    (let [head-var (intern *ns* (gensym "head-")
+                           (fn [req] [:link {:href (:css req)}]))]
+      (is (= [:link {:href "/app.css"}]
+             (routes/resolve-head head-var {:css "/app.css"}))))))

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -119,6 +119,21 @@
       (is (.contains (:body response) "data-hyper-head")
           "Head elements are marked for SSE management")))
 
+  (testing "Allows :head to be a Var containing a function"
+    (let [app-state* (atom (state/init-state))
+          head-var   (intern *ns* (gensym "head-")
+                             (fn [_req] [[:meta {:name "test-head" :content "from-var"}]]))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          handler    (server/create-handler routes app-state*
+                                            {:head head-var})
+          response   (handler {:uri "/" :request-method :get})]
+      (is (= 200 (:status response)))
+      (is (.contains (:body response) "name=\"test-head\""))
+      (is (.contains (:body response) "content=\"from-var\""))
+      (is (.contains (:body response) "data-hyper-head")
+          "Head elements are marked for SSE management")))
+
   (testing "Head elements render as HTML inside <head>, not as escaped text in <body>"
     (let [app-state* (atom (state/init-state))
           routes     [["/" {:name :home
@@ -331,7 +346,37 @@
           routes     [["/" {:name :home
                             :get  (fn [_req] [:div "Home"])}]]
           _handler   (server/create-handler routes app-state* {})]
-      (is (= [] (:global-watches @app-state*))))))
+      (is (= [] (:global-watches @app-state*)))))
+
+  (testing "Var-based :head is auto-added to global-watches"
+    (let [app-state* (atom (state/init-state))
+          head-var   (intern *ns* (gensym "head-")
+                             (fn [_req] [:style "body{}"]))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          _handler   (server/create-handler routes app-state*
+                                            {:head head-var})]
+      (is (= [head-var] (:global-watches @app-state*)))))
+
+  (testing "Non-Var :head does not add to global-watches"
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          _handler   (server/create-handler routes app-state*
+                                            {:head [:style "body{}"]})]
+      (is (= [] (:global-watches @app-state*)))))
+
+  (testing "Combining :watches and Var :head"
+    (let [app-state* (atom (state/init-state))
+          global-src (atom 0)
+          head-var   (intern *ns* (gensym "head-")
+                             (fn [_req] [:style "body{}"]))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          _handler   (server/create-handler routes app-state*
+                                            {:watches [global-src]
+                                             :head    head-var})]
+      (is (= [global-src head-var] (:global-watches @app-state*))))))
 
 (deftest test-server-lifecycle
   (testing "Server start and stop"


### PR DESCRIPTION
Looks like missed functionality while `title` and `<body>` already supports it. 
This PR adds the ability to pass `:head` as a Var to `create-handler`, enabling live-reloading of `<head>` content without page refresh. #20 