### PR TITLE
Allow the Datastar script to be overridden or suppressed

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,6 +33,7 @@
  {:test {:extra-paths ["test"]
          :extra-deps  {org.clojure/test.check     {:mvn/version "1.1.3"}
                        lambdaisland/kaocha        {:mvn/version "1.91.1392"}
+                       nubank/matcher-combinators {:mvn/version "3.10.0"}
                        io.github.pfeodrippe/wally {:mvn/version "0.0.5"}}
          :main-opts   ["-m" "kaocha.runner"]
          :exec-fn     kaocha.runner/exec-fn

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -282,6 +282,7 @@
 
    Options (keyword arguments):
    - :app-state         — Atom for application state (default: fresh atom)
+   - :datastar-script   - Override of the default datastar script (as Hiccup) or nil to suppress
    - :head              — Hiccup nodes appended to the HTML <head>, or (fn [req] ...) -> hiccup
    - :static-resources  — Classpath resource root(s) to serve as static assets
    - :static-dir        — Filesystem directory (or directories) to serve as static assets
@@ -314,10 +315,12 @@
      (def app (start! handler {:port 3000}))
      ;; Later...
      (stop! app)"
-  [routes & {:keys [app-state head static-resources static-dir watches]
-             :or   {app-state (atom (state/init-state))}}]
+  [routes & {:keys [app-state head static-resources static-dir watches datastar-script]
+             :or   {app-state (atom (state/init-state))
+                    datastar-script server/default-datastar-script}}]
   (server/create-handler routes app-state
                          {:head             head
+                          :datastar-script  datastar-script
                           :static-resources static-resources
                           :static-dir       static-dir
                           :watches          watches}))

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -316,7 +316,7 @@
      ;; Later...
      (stop! app)"
   [routes & {:keys [app-state head static-resources static-dir watches datastar-script]
-             :or   {app-state (atom (state/init-state))
+             :or   {app-state       (atom (state/init-state))
                     datastar-script server/default-datastar-script}}]
   (server/create-handler routes app-state
                          {:head             head

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -165,8 +165,8 @@
                          :max-age   (* 60 60 24 7)}) ;; 7 days
               response)))))))
 
-(defn datastar-script
-  "Returns the Datastar CDN script tag."
+(defn default-datastar-script
+  "Returns the default Datastar CDN script tag."
   []
   [:script {:type "module"
             :src  "https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js"}])
@@ -339,10 +339,8 @@
    re-resolution, title/head resolution).
 
    Options:
-   - :head Hiccup nodes to append into the <head>, or (fn [req] ...) -> hiccup.
-           When head is a function, it is re-evaluated on each SSE render cycle
-           and the full <head> is pushed to the client."
-  [app-state* _opts]
+   - :datastar-script - Hiccup content for Datastar script added to document head, or nil."
+  [app-state* {:keys [datastar-script]}]
   (fn [render-fn]
     (fn [req]
       (let [tab-id     (:hyper/tab-id req)
@@ -365,7 +363,7 @@
                                                            [:meta {:charset "UTF-8"}]
                                                            [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
                                                            [:title title]
-                                                           (datastar-script)
+                                                           datastar-script
                                                            (when head-html (c/raw head-html))]
                                                           [:body
                                                            {:data-init (str "@get('/hyper/events?tab-id=" tab-id "', {openWhenHidden: true})")}
@@ -494,6 +492,7 @@
    Options:
    - :head              Hiccup nodes appended to the <head> (e.g. stylesheet <link>),
                         or (fn [req] ...) -> hiccup nodes appended to the <head>
+   - :datastar-script   Hiccup nodes for the Datastar script (or nil to suppress)                           
    - :static-resources  Classpath resource root(s) to serve as static assets
    - :static-dir        Filesystem directory (or directories) to serve as static assets
    - :watches           Vector of Watchable sources added to every page route.
@@ -503,7 +502,7 @@
    Routes should use :get handlers that return hiccup (Chassis vectors).
    Hyper will wrap them to provide full HTML responses and SSE connections."
   ([routes app-state*]
-   (create-handler routes app-state* {}))
+   (create-handler routes app-state* {:datastar-script (default-datastar-script)}))
   ([routes app-state* {:keys [watches head] :as opts}]
    (let [page-wrapper                             (page-handler app-state* opts)
          system-routes                            [["/hyper/events" {:get (sse-events-handler app-state*)}]

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -2,14 +2,14 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [clojure.test :refer [deftest is testing]]
-            [matcher-combinators.test :refer [match?]]
-            [matcher-combinators.matchers :as m]
             [hyper.actions :as actions]
             [hyper.render :as render]
             [hyper.routes :as routes]
             [hyper.server :as server]
             [hyper.state :as state]
-            [hyper.watch :as watch]))
+            [hyper.watch :as watch]
+            [matcher-combinators.matchers :as m]
+            [matcher-combinators.test :refer [match?]]))
 
 (deftest test-generate-session-id
   (testing "Session ID generation"
@@ -135,8 +135,7 @@
       (is (match?
             {:status 200
              :body   (m/pred #(string/includes? % "<script src=\"something-else.js\">"))}
-            response))
-      (is (= 200 (:status response)))))
+            response))))
 
   (testing "Datastar script suppress"
     (let [app-state* (atom (state/init-state))
@@ -150,8 +149,7 @@
       (is (match?
             {:status 200
              :body   (m/pred #(not (string/includes? % "<script src=")))}
-            response))
-      (is (= 200 (:status response)))))
+            response))))
 
   (testing "Allows :head to be a Var containing a function"
     (let [app-state* (atom (state/init-state))

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -1,6 +1,9 @@
 (ns hyper.server-test
   (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [clojure.test :refer [deftest is testing]]
+            [matcher-combinators.test :refer [match?]]
+            [matcher-combinators.matchers :as m]
             [hyper.actions :as actions]
             [hyper.render :as render]
             [hyper.routes :as routes]
@@ -71,13 +74,14 @@
 
       (is (.contains (:body response) "tab: tab-from-query")))))
 
-(deftest test-datastar-script
+(deftest test-default-datastar-script
   (testing "Datastar script tag generation"
-    (let [script (server/datastar-script)]
+    (let [script (server/default-datastar-script)]
       (is (vector? script))
-      (is (= :script (first script)))
-      (is (contains? (second script) :src))
-      (is (.contains (get (second script) :src) "datastar")))))
+      (is (match?
+            [:script {:src  #".*datastar.*"
+                      :type "module"}]
+            script)))))
 
 (deftest test-create-handler
   (testing "Creates a working ring handler"
@@ -118,6 +122,36 @@
       (is (.contains (:body response) "content=\"ok\""))
       (is (.contains (:body response) "data-hyper-head")
           "Head elements are marked for SSE management")))
+
+  (testing "Datastar script override"
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          handler    (server/create-handler routes app-state*
+                                            {:head            (fn [_req]
+                                                                [[:meta {:name "test" :content "ok"}]])
+                                             :datastar-script [:script {:src "something-else.js"}]})
+          response   (handler {:uri "/" :request-method :get})]
+      (is (match?
+            {:status 200
+             :body   (m/pred #(string/includes? % "<script src=\"something-else.js\">"))}
+            response))
+      (is (= 200 (:status response)))))
+
+  (testing "Datastar script suppress"
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          handler    (server/create-handler routes app-state*
+                                            {:head            (fn [_req]
+                                                                [[:meta {:name "test" :content "ok"}]])
+                                             :datastar-script nil})
+          response   (handler {:uri "/" :request-method :get})]
+      (is (match?
+            {:status 200
+             :body   (m/pred #(not (string/includes? % "<script src=")))}
+            response))
+      (is (= 200 (:status response)))))
 
   (testing "Allows :head to be a Var containing a function"
     (let [app-state* (atom (state/init-state))


### PR DESCRIPTION
Adds a new option, :datastar-script, to hyper.core/create-handler and hyper.server/create-handler