### PR TITLE
Investigate setting/getting cookies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -191,6 +191,34 @@ Example usage:
 
 When `$` symbols appear in the action body, the macro automatically generates a `fetch()` call instead of `@post()`, sending the extracted values as a JSON body. On the server, the action function receives these values bound to the corresponding `$` symbols.
 
+### Cookies (Experimental!)
+
+Cookies can be set from inside your action handler by calling the `h/set-cookie!` function:
+
+```clojure
+(h/set-cookie! "my-auth-token" my-token
+  {:http-only true
+   :secure    true
+   :path      "/"
+   :max-age   (* 60 60 24 30)})
+```
+
+Setting the same named token to max-age 0 with a matching path string will un-set the cookie:
+```clojure
+(h/set-cookie! "my-auth-token" "anything"
+  {:path      "/"
+   :max-age   0})
+```
+### Receiving cookie values
+
+When constructing your Hyper handler, add the parameter `:before-render` and supply a function which receives the Ring request when the browser first requests the page.
+
+You can read the cookie value `(get-in req [:cookies "my-auth-token" :value])`, check against existing cursors, and if needed, perform initialisation.
+
+For example, if you have a login action handler which sets a session cursor `:me`, you can check if it has a nil value in your before-render handler, and if your cookie is present, use this to identify the user and re-init session level values.
+
+You could use JWTs, or any other type of token to provide a "remember me" type of login flow, with the usual caveat that the cookie should have some signing/encryption to prevent tampering.
+
 ## Navigation
 
 Hyper uses [Reitit](https://github.com/metosin/reitit) for routing. Routes are

--- a/Readme.md
+++ b/Readme.md
@@ -191,7 +191,7 @@ Example usage:
 
 When `$` symbols appear in the action body, the macro automatically generates a `fetch()` call instead of `@post()`, sending the extracted values as a JSON body. On the server, the action function receives these values bound to the corresponding `$` symbols.
 
-### Cookies (Experimental!)
+### Cookies
 
 Cookies can be set from inside your action handler by calling the `h/set-cookie!` function:
 
@@ -203,12 +203,12 @@ Cookies can be set from inside your action handler by calling the `h/set-cookie!
    :max-age   (* 60 60 24 30)})
 ```
 
-Setting the same named token to max-age 0 with a matching path string will un-set the cookie:
+Deleting a cookie can be done with `h/delete-cookie!`. It sets the cookie again but with max-age 0. You must use the same path as you used to set it in the first place:
 ```clojure
-(h/set-cookie! "my-auth-token" "anything"
-  {:path      "/"
-   :max-age   0})
+(h/delete-cookie! "my-auth-token" "/")
 ```
+You can omit the path parameter to default in "/".
+
 ### Receiving cookie values
 
 When constructing your Hyper handler, add the parameter `:before-render` and supply a function which receives the Ring request when the browser first requests the page.

--- a/src/hyper/context.clj
+++ b/src/hyper/context.clj
@@ -12,6 +12,10 @@
 ;; enabling effective brotli streaming compression.
 (def ^:dynamic *action-idx* nil)
 
+;; Atom accumulating cookies to be set on the action HTTP response.
+;; Bound to a fresh atom before each action execution; nil outside actions.
+(def ^:dynamic *pending-cookies* nil)
+
 (defn require-context!
   "Extract and validate the request context from *request*.
    Throws if called outside a request context or if required keys are missing.

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -154,6 +154,31 @@
            "',{method:'POST',headers:{'Content-Type':'application/json'}"
            ",body:JSON.stringify({" json-entries "})})"))))
 
+(defn set-cookie!
+  "Set a cookie on the HTTP response for the current action.
+   Must be called from within an action handler (i.e. inside an `action` body).
+
+   name:  Cookie name string
+   value: Cookie value string
+   opts:  Map of Ring cookie options — any subset of:
+     :http-only  — boolean, prevents JS access (recommended: true)
+     :secure     — boolean, HTTPS-only (recommended: true in production)
+     :max-age    — integer seconds until expiry
+     :path       — string (default \"/\")
+     :same-site  — :strict, :lax, or :none
+     :domain     — string
+
+   Example:
+     (action
+       (when-let [user (authenticate! $form-data)]
+         (reset! (session-cursor :user) user)
+         (set-cookie! \"auth-token\" (:jwt user)
+                      {:http-only true :secure true :max-age (* 60 60 24 30)})))"
+  [name value opts]
+  (if context/*pending-cookies*
+    (swap! context/*pending-cookies* assoc name (assoc opts :value value))
+    (throw (ex-info "set-cookie! called outside an action context" {:cookie-name name}))))
+
 (defmacro action
   "Create a server action expression for use in Datastar event attributes.
    Returns a Datastar expression string that can be bound to any event.
@@ -289,6 +314,10 @@
    - :watches           — Vector of Watchable sources added to every page route.
                           Useful for top-level atoms that should trigger a re-render
                           on any page (e.g. a global config or feature-flags atom).
+   - :before-render     — (fn [req] ...) called on every initial page load before the
+                          route's render function runs, with the request context bound.
+                          Use this to restore session state from long-lived cookies
+                          (e.g. a JWT auth token). Has full access to cursor functions.
 
    Example:
      (def routes
@@ -315,7 +344,7 @@
      (def app (start! handler {:port 3000}))
      ;; Later...
      (stop! app)"
-  [routes & {:keys [app-state head static-resources static-dir watches datastar-script]
+  [routes & {:keys [app-state head static-resources static-dir watches datastar-script before-render]
              :or   {app-state       (atom (state/init-state))
                     datastar-script server/default-datastar-script}}]
   (server/create-handler routes app-state
@@ -323,7 +352,8 @@
                           :datastar-script  datastar-script
                           :static-resources static-resources
                           :static-dir       static-dir
-                          :watches          watches}))
+                          :watches          watches
+                          :before-render    before-render}))
 
 (defn start!
   "Start the hyper application server.

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -158,6 +158,8 @@
   "Set a cookie on the HTTP response for the current action.
    Must be called from within an action handler (i.e. inside an `action` body).
 
+   Un-set a cookie by setting :max-age to 0 and the same :path as the original.
+
    name:  Cookie name string
    value: Cookie value string
    opts:  Map of Ring cookie options — any subset of:

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -158,8 +158,6 @@
   "Set a cookie on the HTTP response for the current action.
    Must be called from within an action handler (i.e. inside an `action` body).
 
-   Un-set a cookie by setting :max-age to 0 and the same :path as the original.
-
    name:  Cookie name string
    value: Cookie value string
    opts:  Map of Ring cookie options — any subset of:
@@ -180,6 +178,14 @@
   (if context/*pending-cookies*
     (swap! context/*pending-cookies* assoc name (assoc opts :value value))
     (throw (ex-info "set-cookie! called outside an action context" {:cookie-name name}))))
+
+(defn delete-cookie!
+  "Delete a cookie by setting :max-age to 0. You must use the same path as the original cookie has."
+  ([name] (delete-cookie! name "/"))
+  ([name path]
+   (if context/*pending-cookies*
+     (swap! context/*pending-cookies* assoc name {:value "" :max-age 0 :path path})
+     (throw (ex-info "delete-cookie! called outside an action context" {:cookie-name name})))))
 
 (defmacro action
   "Create a server action expression for use in Datastar event attributes.

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -245,17 +245,21 @@
          :headers {"Content-Type" "application/json"}
          :body    "{\"error\": \"Missing action-id\"}"}
 
-        (let [req-with-state (assoc req
-                                    :hyper/app-state app-state*
-                                    :hyper/router (get @app-state* :router))
-              client-params  (parse-client-params req)]
-          (push-thread-bindings {#'context/*request* req-with-state})
+        (let [req-with-state  (assoc req
+                                     :hyper/app-state app-state*
+                                     :hyper/router (get @app-state* :router))
+              client-params   (parse-client-params req)
+              pending-cookies* (atom {})]
+          (push-thread-bindings {#'context/*request*         req-with-state
+                                 #'context/*pending-cookies* pending-cookies*})
           (try
             (actions/execute-action! app-state* action-id client-params)
-
-            {:status  200
-             :headers {"Content-Type" "application/json"}
-             :body    "{\"success\": true}"}
+            (let [base {:status  200
+                        :headers {"Content-Type" "application/json"}
+                        :body    "{\"success\": true}"}]
+              (if (seq @pending-cookies*)
+                (update base :cookies merge @pending-cookies*)
+                base))
 
             (catch Exception e
               (t/error! e
@@ -339,8 +343,12 @@
    re-resolution, title/head resolution).
 
    Options:
-   - :datastar-script - Hiccup content for Datastar script added to document head, or nil."
-  [app-state* {:keys [datastar-script]}]
+   - :datastar-script - Hiccup content for Datastar script added to document head, or nil.
+   - :before-render   - (fn [req] ...) called on every initial page load before the route's
+                        render function runs, with context/*request* bound. Use this to
+                        restore session state from long-lived cookies (e.g. a JWT auth token).
+                        Has full access to cursor functions (session-cursor, tab-cursor, etc.)."
+  [app-state* {:keys [datastar-script before-render]}]
   (fn [render-fn]
     (fn [req]
       (let [tab-id     (:hyper/tab-id req)
@@ -349,6 +357,10 @@
 
         (render/register-render-fn! app-state* tab-id render-fn)
         (state/set-tab-route! app-state* tab-id route-info)
+
+        (when before-render
+          (binding [context/*request* req]
+            (before-render req)))
 
         (let [result (render/render-tab app-state* session-id tab-id req)]
           ;; Ring response passthrough (e.g. a 302 redirect)
@@ -492,12 +504,16 @@
    Options:
    - :head              Hiccup nodes appended to the <head> (e.g. stylesheet <link>),
                         or (fn [req] ...) -> hiccup nodes appended to the <head>
-   - :datastar-script   Hiccup nodes for the Datastar script (or nil to suppress)                           
+   - :datastar-script   Hiccup nodes for the Datastar script (or nil to suppress)
    - :static-resources  Classpath resource root(s) to serve as static assets
    - :static-dir        Filesystem directory (or directories) to serve as static assets
    - :watches           Vector of Watchable sources added to every page route.
                         Useful for top-level atoms that should trigger a re-render
                         on any page (e.g. a global config or feature-flags atom).
+   - :before-render     (fn [req] ...) called on every initial page load before the
+                        route's render function runs. Use this to restore session state
+                        from long-lived cookies (e.g. a JWT auth token). Has full access
+                        to cursor functions (session-cursor, tab-cursor, etc.).
 
    Routes should use :get handlers that return hiccup (Chassis vectors).
    Hyper will wrap them to provide full HTML responses and SSE connections."

--- a/test/hyper/core_test.clj
+++ b/test/hyper/core_test.clj
@@ -200,6 +200,13 @@
       (is (= "second" (get-in @context/*pending-cookies* ["auth-token" :value])))
       (is (= 200 (get-in @context/*pending-cookies* ["auth-token" :max-age]))))))
 
+(deftest test-delete-cookie
+  (testing "accumulates a cookie with max-age 0 into *pending-cookies*"
+    (binding [context/*pending-cookies* (atom {})]
+      (hy/delete-cookie! "auth-token")
+      (is (= {"auth-token" {:max-age 0 :path "/" :value ""}}
+             @context/*pending-cookies*)))))
+
 (deftest test-create-handler
   (testing "creates handler with default app-state"
     (let [routes  [["/" {:name :home

--- a/test/hyper/core_test.clj
+++ b/test/hyper/core_test.clj
@@ -173,6 +173,33 @@
           ;; Render fn should be swapped
           (is (= about-fn (get-in @app-state* [:tabs tab-id :render-fn]))))))))
 
+(deftest test-set-cookie
+  (testing "throws when called outside an action context"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"outside an action context"
+                          (hy/set-cookie! "foo" "bar" {}))))
+
+  (testing "accumulates a cookie into *pending-cookies*"
+    (binding [context/*pending-cookies* (atom {})]
+      (hy/set-cookie! "auth-token" "my-jwt" {:http-only true :max-age 86400 :path "/"})
+      (is (= {"auth-token" {:value "my-jwt" :http-only true :max-age 86400 :path "/"}}
+             @context/*pending-cookies*))))
+
+  (testing "multiple calls accumulate all cookies"
+    (binding [context/*pending-cookies* (atom {})]
+      (hy/set-cookie! "auth-token" "jwt-value" {:http-only true})
+      (hy/set-cookie! "theme" "dark" {:max-age (* 60 60 24 365)})
+      (is (= 2 (count @context/*pending-cookies*)))
+      (is (= "jwt-value" (get-in @context/*pending-cookies* ["auth-token" :value])))
+      (is (= "dark" (get-in @context/*pending-cookies* ["theme" :value])))))
+
+  (testing "later call overwrites earlier call for the same cookie name"
+    (binding [context/*pending-cookies* (atom {})]
+      (hy/set-cookie! "auth-token" "first" {:max-age 100})
+      (hy/set-cookie! "auth-token" "second" {:max-age 200})
+      (is (= 1 (count @context/*pending-cookies*)))
+      (is (= "second" (get-in @context/*pending-cookies* ["auth-token" :value])))
+      (is (= 200 (get-in @context/*pending-cookies* ["auth-token" :max-age]))))))
+
 (deftest test-create-handler
   (testing "creates handler with default app-state"
     (let [routes  [["/" {:name :home

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -3,6 +3,7 @@
             [clojure.string :as string]
             [clojure.test :refer [deftest is testing]]
             [hyper.actions :as actions]
+            [hyper.core :as hy]
             [hyper.render :as render]
             [hyper.routes :as routes]
             [hyper.server :as server]
@@ -515,3 +516,78 @@
           response   (handler {:uri "/" :request-method :get})]
       (is (= 200 (:status response)))
       (is (.contains (:body response) "Static")))))
+
+(deftest test-action-handler-set-cookie
+  (testing "action calling set-cookie! returns :cookies in response"
+    (let [app-state* (atom (state/init-state))
+          action-fn  (fn [_]
+                       (hy/set-cookie! "auth-token" "my-jwt"
+                                       {:http-only true :secure true
+                                       :max-age   86400 :path "/"}))
+          action-id  (actions/register-action! app-state* "s1" "t1" action-fn "set-cookie-action")
+          handler    (server/action-handler app-state*)
+          response   (handler {:query-params {"action-id" action-id}})]
+      (is (= 200 (:status response)))
+      (is (contains? (:cookies response) "auth-token"))
+      (is (= "my-jwt" (get-in response [:cookies "auth-token" :value])))
+      (is (true? (get-in response [:cookies "auth-token" :http-only])))
+      (is (= 86400 (get-in response [:cookies "auth-token" :max-age])))))
+
+  (testing "action with no set-cookie! call returns no :cookies key"
+    (let [app-state* (atom (state/init-state))
+          action-fn  (fn [_] nil)
+          action-id  (actions/register-action! app-state* "s1" "t1" action-fn "no-cookie-action")
+          handler    (server/action-handler app-state*)
+          response   (handler {:query-params {"action-id" action-id}})]
+      (is (= 200 (:status response)))
+      (is (nil? (seq (:cookies response))))))
+
+  (testing "multiple set-cookie! calls in one action all appear in response"
+    (let [app-state* (atom (state/init-state))
+          action-fn  (fn [_]
+                       (hy/set-cookie! "auth-token" "jwt-abc" {:http-only true :max-age 86400})
+                       (hy/set-cookie! "theme" "dark" {:max-age (* 60 60 24 365)}))
+          action-id  (actions/register-action! app-state* "s1" "t1" action-fn "multi-cookie-action")
+          handler    (server/action-handler app-state*)
+          response   (handler {:query-params {"action-id" action-id}})]
+      (is (= 200 (:status response)))
+      (is (= "jwt-abc" (get-in response [:cookies "auth-token" :value])))
+      (is (= "dark" (get-in response [:cookies "theme" :value]))))))
+
+(deftest test-before-render
+  (testing "before-render fn is called on initial page load"
+    (let [called?    (atom false)
+          app-state* (atom (state/init-state))
+          routes     [["/" {:name :home :get (fn [_] [:div "Home"])}]]
+          handler    (server/create-handler routes app-state*
+                                            {:before-render (fn [_req] (reset! called? true))})]
+      (handler {:uri "/" :request-method :get})
+      (is @called?)))
+
+  (testing "before-render receives the full ring request including parsed cookies"
+    (let [received-req (atom nil)
+          app-state*   (atom (state/init-state))
+          routes       [["/" {:name :home :get (fn [_] [:div "Home"])}]]
+          handler      (server/create-handler routes app-state*
+                                              {:before-render (fn [req] (reset! received-req req))})]
+      (handler {:uri            "/"
+                :request-method :get
+                :headers        {"cookie" "auth-token=my-jwt"}})
+      (is (some? @received-req))
+      (is (= "my-jwt" (get-in @received-req [:cookies "auth-token" :value])))))
+
+  (testing "before-render can use cursor functions to restore session state from a cookie"
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home :get (fn [_] [:div "Home"])}]]
+          handler    (server/create-handler
+                       routes app-state*
+                       {:before-render (fn [req]
+                                         (when-let [jwt (get-in req [:cookies "auth-token" :value])]
+                                           (reset! (hy/session-cursor :user) {:token jwt})))})]
+      (handler {:uri            "/"
+                :request-method :get
+                :headers        {"cookie" "auth-token=test-token-123"}})
+      (let [session-id (first (keys (:sessions @app-state*)))]
+        (is (some? session-id))
+        (is (= {:token "test-token-123"}
+               (get-in @app-state* [:sessions session-id :data :user])))))))


### PR DESCRIPTION
Hi Ryan this is Simon (aka mangofarmer on slack...) - I've had a go at implementing support for setting and receiving cookies. Disclaimer: I used Claude Code but it looks like a nice solution to me, but I'm not really familiar with the hyper codebase or datastar but it seems to fit in ok with the other parts of Hyper.

My goal was to support the flow where an authentication form can set a long lived cookie when authentication succeeds, and if the user returns to the site and their normal session token has expired, you can detect this in a "before-render" handler.  At this point you have access to the ring request to get at cookies, and the bound context so you can also manipulate cursors.  You can then validate something like a jwt and retrieve the same session data that you might have set up after logging in.

I'm not 100% certain you can use set-cookie in all situations, related to the SSE side of things, but an action handler on form submission and just a normal button on-click seems to work.

Feel free to change whatever you'd like etc!