### PR TITLE
fix: omit nil query params from build-url

### DIFF
--- a/src/hyper/state.clj
+++ b/src/hyper/state.clj
@@ -211,12 +211,16 @@
 
 (defn build-url
   "Build a URL string from a path and query params map.
-   Returns path if no query params."
+   Omits query params with nil values.
+   Returns path if no query params remain."
   [path query-params]
-  (if (or (nil? query-params) (empty? query-params))
-    path
-    (let [query-string (->> query-params
-                            (map (fn [[k v]]
-                                   (str (name k) "=" (java.net.URLEncoder/encode (str v) "UTF-8"))))
-                            (clojure.string/join "&"))]
-      (str path "?" query-string))))
+  (let [non-nil-query-params (into {}
+                                   (remove (comp nil? val))
+                                   query-params)]
+    (if (empty? non-nil-query-params)
+      path
+      (let [query-string (->> non-nil-query-params
+                              (map (fn [[k v]]
+                                     (str (name k) "=" (java.net.URLEncoder/encode (str v) "UTF-8"))))
+                              (clojure.string/join "&"))]
+        (str path "?" query-string)))))

--- a/test/hyper/state_test.clj
+++ b/test/hyper/state_test.clj
@@ -282,3 +282,17 @@
         (swap! cursor-b + 5)
         (is (= 6 @cursor-a))
         (is (= 6 @cursor-b))))))
+
+(deftest build-url-test
+  (testing "returns path when query params are nil or empty"
+    (is (= "/search" (state/build-url "/search" nil)))
+    (is (= "/search" (state/build-url "/search" {}))))
+
+  (testing "omits query params with nil values"
+    (is (= "/search" (state/build-url "/search" {:q nil})))
+    (is (= "/search?q=clojure"
+           (state/build-url "/search" {:q "clojure" :page nil}))))
+
+  (testing "preserves empty query param values"
+    (is (= "/search?q="
+           (state/build-url "/search" {:q ""})))))


### PR DESCRIPTION
Omit nil-valued query params when building URLs.

This keeps nil query params out of the visible URL while preserving normal cursor/atom semantics in route state.

Adds tests for:
- nil query params being omitted
- empty query params still rendering as ?q=
