### PR TITLE
feat: allow JS guard expression as first arg to action macro

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -210,6 +210,17 @@ the browser to the hyper application.
 With this in place, your `h/action` code can reference symbol `$mouse-offset`, which will be
 an EDN map with keys :x and :y.
 
+### Client-side guards
+
+Pass a `:when` option to `action` to inject a client-side Datastar expression. 
+The guard runs before the action fires, letting you filter events at the browser level without a server round-trip.
+
+```clojure
+;; Only POST when Enter is pressed — no network traffic on other keystrokes
+[:input {:type "text"
+         :data-on:keydown (h/action {:when "evt.key === 'Enter'"}
+                           (reset! (h/tab-cursor :value) $value))}]
+```
 
 ## Navigation
 

--- a/example/example/app.clj
+++ b/example/example/app.clj
@@ -67,6 +67,7 @@
           (result [label content]
             [:p label [:strong content]])]
     (let [text*    (h/tab-cursor :text "")
+          value*   (h/tab-cursor :value "")
           checked* (h/tab-cursor :dark-mode false)
           key*     (h/tab-cursor :last-key "")
           select*  (h/tab-cursor :color "red")
@@ -111,6 +112,13 @@
                        :placeholder     "Press a key…"
                        :data-on:keydown (h/action (reset! (h/tab-cursor :last-key) $key))}]
               (result "Last key: " (if (seq @key*) @key* "none yet")))
+
+        (card "Javascript injection — client side await for Enter keystroke"
+              "Await the Enter keystroke to send the input value to the server."
+              [:input {:type            "text"
+                       :placeholder     "Type something…"
+                       :data-on:keydown (h/action {:when "evt.key === 'Enter'"} (reset! (h/tab-cursor :value) $value))}]
+              (result "Server sees: " (if (seq @value*) @value* "nothing yet")))
 
         ;; $form-data — form submission
         (card "$form-data — Form Submission"

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -138,18 +138,22 @@
   "Build the Datastar/JS expression string for an action.
    When no client params are needed, returns a simple @post expression.
    When client params are present, returns a fetch() call that sends
-   the extracted DOM values as a JSON POST body."
-  [action-id used-params]
-  (if (empty? used-params)
-    (str "@post('/hyper/actions?action-id=" action-id "')")
-    (let [json-entries (->> used-params
-                            vals
-                            (map (fn [{:keys [js key]}]
-                                   (str key ":" js)))
-                            (str/join ","))]
-      (str "fetch('/hyper/actions?action-id=" action-id
-           "',{method:'POST',headers:{'Content-Type':'application/json'}"
-           ",body:JSON.stringify({" json-entries "})})"))))
+   the extracted DOM values as a JSON POST body.
+   Optionally injects custom Datastar expression to conditionally prevent post/fetch.
+   "
+  [action-id used-params js]
+  (let [js-injection (when js (str js " && "))]
+    (if (empty? used-params)
+      (str js-injection "@post('/hyper/actions?action-id=" action-id "')")
+      (let [json-entries (->> used-params
+                              vals
+                              (map (fn [{:keys [js key]}]
+                                     (str key ":" js)))
+                              (str/join ","))]
+        (str js-injection
+             "fetch('/hyper/actions?action-id=" action-id
+             "',{method:'POST',headers:{'Content-Type':'application/json'}"
+             ",body:JSON.stringify({" json-entries "})})")))))
 
 (defmacro action
   "Create a server action expression for use in Datastar event attributes.
@@ -174,7 +178,12 @@
      [:input {:data-on:change (action (reset! (tab-cursor :query) $value))}]
 
      ;; Keyboard shortcut
-     [:input {:data-on:keydown (action (when (= $key \"Enter\") (search!)))}]
+     [:input {:data-on:keydown (action (when (= $key \"Enter\")
+                                 (search!)))}]
+
+     ;; ... with client side check
+     [:input {:data-on:keydown (action {:when \"evt.key === 'Enter'\"}
+                                 (search!))}]
 
      ;; Checkbox
      [:input {:type \"checkbox\"
@@ -187,10 +196,18 @@
       
      Applications may define additional client parameters by extending
      the hyper.client-params/client-param multi-method."
-  [& body]
-  (let [used-params (find-client-params body)
-        param-syms  (keys used-params)
-        cp-sym      (gensym "client-params")]
+  [& args]
+  (let [[maybe-opts & body] args
+        [js body]           (if-let [guard (:when maybe-opts)]
+                              [(if (and (string? guard)
+                                        (not (str/blank? guard)))
+                                 guard
+                                 nil)
+                               body]
+                              [nil args])
+        used-params         (find-client-params body)
+        param-syms          (keys used-params)
+        cp-sym              (gensym "client-params")]
     `(let [{session-id# :session-id
             tab-id#     :tab-id
             app-state*# :app-state*
@@ -208,7 +225,7 @@
            idx#                     (if context/*action-idx* (swap! context/*action-idx* inc) (hash action-fn#))
            action-id#               (str "a-" tab-id# "-" idx#)
            _#                       (actions/register-action! app-state*# session-id# tab-id# action-fn# action-id#)]
-       (build-action-expr action-id# '~used-params))))
+       (build-action-expr action-id# '~used-params ~js))))
 
 (defn navigate
   "Create a navigation link using reitit named routes.

--- a/test/hyper/core_test.clj
+++ b/test/hyper/core_test.clj
@@ -397,4 +397,39 @@
                                          (reset! (hy/tab-cursor :k) $key)))]
           (is (.contains action-expr "fetch("))
           (is (.contains action-expr "value:evt.target.value"))
-          (is (.contains action-expr "key:evt.key")))))))
+          (is (.contains action-expr "key:evt.key"))))))
+
+  (testing "JS string with client params injects guard before fetch"
+    (let [app-state* (atom (state/init-state))
+          session-id "test-session-js"
+          tab-id     "test-tab-js"]
+      (state/get-or-create-tab! app-state* session-id tab-id)
+      (binding [context/*request* {:hyper/session-id session-id
+                                   :hyper/tab-id     tab-id
+                                   :hyper/app-state  app-state*}]
+        (let [action-expr (hy/action {:when "evt.key === 'Enter'"}
+                                     (reset! (hy/tab-cursor :val) $value))]
+          (is (string? action-expr))
+          (is (.contains action-expr "evt.key === 'Enter'"))
+          (is (.contains action-expr "fetch("))
+          (is (.contains action-expr "value:evt.target.value"))
+          (is (not (.contains action-expr "@post")))
+          (is (.startsWith action-expr "evt.key === 'Enter' && "))
+          ;; Verify action executes correctly with client params
+          (let [action-id (second (re-find #"action-id=([^'&\"]+)" action-expr))]
+            (is (some? action-id))
+            ((get-in @app-state* [:actions action-id :fn]) {:value "hello"})
+            (is (= "hello" (get-in @app-state* [:tabs tab-id :data :val]))))))))
+
+  (testing "empty :when string treated as no JS injection"
+    (let [app-state* (atom (state/init-state))
+          session-id "test-session-js"
+          tab-id     "test-tab-js"]
+      (state/get-or-create-tab! app-state* session-id tab-id)
+      (binding [context/*request* {:hyper/session-id session-id
+                                   :hyper/tab-id     tab-id
+                                   :hyper/app-state  app-state*}]
+        (let [action-expr (hy/action {:when ""} (reset! (hy/tab-cursor :val) $value))]
+          (is (.contains action-expr "fetch("))
+          (is (.contains action-expr "value:evt.target.value"))
+          (is (not (.contains action-expr " && "))))))))


### PR DESCRIPTION
Implements the JS injection feature discussed in #18.

The `action` macro now accepts an optional JavaScript expression string as the first argument. When provided, it is prepended as a client-side guard (`&&`) before the `@post()` or `fetch()` expression.

**Use case:** Filter events at the browser side (e.g., check for Enter key) without sending a server request on every keystroke.

**Example:**
```clojure
[:input {:type "text"
         :data-on:keydown (h/action "evt.key === 'Enter'"
                           (reset! (h/tab-cursor :value) $value))}]
```

**Changes:**
- `src/hyper/core.clj` — `build-action-expr` takes optional `js` arg, `action` macro parses leading string
- `example/example/app.clj` — demo card showing JS guard in action
- `test/hyper/core_test.clj` — test verifying guard injection + execution

Closes #18