### PR TITLE
fix: reload restored documents after history navigation

### DIFF
--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -337,6 +337,8 @@
    - MutationObserver on #hyper-app watches data-hyper-url attribute changes
      and syncs the browser URL bar via replaceState. Title syncing is handled
      server-side by re-rendering the full <head> (including <title>) via SSE.
+   - pageshow listener reloads restored documents so stale tab/action state
+     does not survive browser history restoration.
    - popstate listener handles browser back/forward by posting to /hyper/navigate
      and restoring document.title from history state.
 
@@ -374,6 +376,12 @@
     });
     observer.observe(appEl, { attributes: true, attributeFilter: ['data-hyper-url'] });
   }
+  window.addEventListener('pageshow', function(event) {
+    var nav = performance.getEntriesByType && performance.getEntriesByType('navigation')[0];
+    if (event.persisted || (nav && nav.type === 'back_forward')) {
+      window.location.reload();
+    }
+  });
   window.addEventListener('popstate', function(e) {
     if (e.state && e.state.title) {
       document.title = e.state.title;

--- a/test/hyper/e2e_test.clj
+++ b/test/hyper/e2e_test.clj
@@ -536,6 +536,50 @@
         (close-browser! browser-info)))))
 
 ;; ---------------------------------------------------------------------------
+;; Test 5: History restore reloads stale documents
+;; ---------------------------------------------------------------------------
+
+(deftest ^:e2e history-restore-reload-test
+  (let [browser-info (launch-browser)
+        ctx          (new-context browser-info)
+        page         (new-page ctx)]
+    (try
+      (w/with-page page
+        (w/navigate (str base-url "/counters"))
+        (wait-for-sse)
+        (wait-for-text "#counter-Session h2" "Session: 0")
+
+        (let [initial-action (eval-js "document.querySelector('#counter-Session .inc').getAttribute('data-on:click')")]
+          (click-counter-button "Session" ".inc")
+          (wait-for-text "#counter-Session h2" "Session: 1")
+
+          ;; Leave the Hyper document, then use browser history to return.
+          (.navigate page "data:text/html,<title>Away</title><h1>Away</h1>")
+          (is (= "Away" (w/text-content "h1")))
+          (.goBack page)
+
+          ;; The restored document should reload and register fresh actions.
+          (let [deadline (+ (System/currentTimeMillis) 10000)]
+            (loop []
+              (let [current-action (try (eval-js "document.querySelector('#counter-Session .inc') && document.querySelector('#counter-Session .inc').getAttribute('data-on:click')")
+                                        (catch Exception _ nil))]
+                (if (and current-action (not= initial-action current-action))
+                  (is true)
+                  (if (> (System/currentTimeMillis) deadline)
+                    (is (and current-action (not= initial-action current-action))
+                        (str "Expected Session increment action to change after history restore, but still saw " (pr-str current-action)))
+                    (do (Thread/sleep 100)
+                        (recur)))))))
+
+          (w/wait-for "#hyper-app" {:state :visible :timeout 10000})
+          (wait-for-text "#counter-Session h2" "Session: 1")
+          (click-counter-button "Session" ".inc")
+          (wait-for-text "#counter-Session h2" "Session: 2")))
+
+      (finally
+        (close-browser! browser-info)))))
+
+;; ---------------------------------------------------------------------------
 ;; Test 2: Title changes when route Var is redefined
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Reload pages restored through browser history so stale `action-id`s do not survive after the server has cleaned up the old tab.

This fixes a case where navigating away from a Hyper page and then returning with the browser Back button could leave the page looking normal but no longer responding to clicks.

Adds an e2e regression covering:
- click action
- navigate away
- browser Back
- fresh action works again

In local Safari and Chrome testing it fixed the broken Back-button behavior. Scroll position was preserved in local testing, though restored-page reloads may still be disruptive for things like focus.

Longer term, more complete follow-up options could be TTL/reconnect or morph-style recovery.