### PR TITLE
perf: memoize signal name conversion with camel-snake-kebab

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,6 +115,12 @@ Mutating any cursor triggers a re-render for every tab that depends on that
 scope — global changes re-render all tabs, session changes re-render tabs in
 that session, and so on.
 
+Renders are throttled at `~60fps` (`16 ms` intervals). Multiple cursor mutations
+within the same frame window are batched into a single render. Mutations
+spread across different frame windows produce one render per window.
+For example: a sequence of mutations over 48 ms will result in roughly 3 renders, 
+each reflecting the latest state at that moment.
+
 ## Actions
 
 Actions are server-side functions triggered by user interactions. The `action`

--- a/src/hyper/signal.clj
+++ b/src/hyper/signal.clj
@@ -13,7 +13,9 @@
 
    Local signals (prefixed with underscore in Datastar) are client-only:
    they cannot be read or written from the server."
-  (:require [cheshire.core :as json]
+  (:require [camel-snake-kebab.core :as csk]
+            [cheshire.core :as json]
+            [clojure.core.memoize :as m]
             [clojure.string :as str]
             [dev.onionpancakes.chassis.core :as c]
             [hyper.context :as context]))
@@ -22,20 +24,11 @@
 ;; Name conversion
 ;; ---------------------------------------------------------------------------
 
-(defn- kebab->camel
-  "Convert a kebab-case string to camelCase.
-   \"user-name\" → \"userName\""
-  [s]
-  (let [parts (str/split s #"-")]
-    (apply str (first parts) (map str/capitalize (rest parts)))))
+(def ^:private memoized->camelCaseString
+  (m/fifo csk/->camelCaseString {} :fifo/threshold 1024))
 
-(defn- camel->kebab
-  "Convert a camelCase string to kebab-case.
-   \"userName\" → \"user-name\""
-  [s]
-  (-> s
-      (str/replace #"([a-z0-9])([A-Z])" "$1-$2")
-      str/lower-case))
+(def ^:private memoized->kebab-case-string
+  (m/fifo csk/->kebab-case-string {} :fifo/threshold 1024))
 
 (defn signal-js-name
   "Convert a keyword or keyword vector path to the Datastar signal JS name.
@@ -44,8 +37,8 @@
    [:user-profile :first-name] → \"userProfile.firstName\""
   [path]
   (if (keyword? path)
-    (kebab->camel (name path))
-    (str/join "." (map (comp kebab->camel name) path))))
+    (memoized->camelCaseString (name path))
+    (str/join "." (map (comp memoized->camelCaseString name) path))))
 
 (defn signal-html-name
   "Convert a keyword or keyword vector path to the HTML attribute suffix
@@ -240,7 +233,7 @@
    keyword-keyed map or nil."
   [json-str]
   (when (and json-str (not (str/blank? json-str)))
-    (json/parse-string json-str (fn [k] (keyword (camel->kebab k))))))
+    (json/parse-string json-str (fn [k] (keyword (memoized->kebab-case-string k))))))
 
 ;; ---------------------------------------------------------------------------
 ;; HTML signal attribute generation
@@ -271,7 +264,7 @@
    JSON null (Datastar removes signals set to null)."
   [signal-patches]
   (let [json-str (json/generate-string signal-patches
-                                       {:key-fn (fn [k] (kebab->camel (name k)))})]
+                                       {:key-fn (fn [k] (memoized->camelCaseString (name k)))})]
     (str "event: datastar-patch-signals\n"
          "data: signals " json-str "\n\n")))
 


### PR DESCRIPTION
**perf: memoize signal name conversion** 

Replaced the hand-rolled `kebab->camel` / `camel->kebab` functions with `camel-snake-kebab` lib, wrapped in a FIFO memoized cache (1024 entries via `core.memoize`). Signal name conversion runs on every render for every signal attribute — memoizing avoids repeated regex replacements and allocations.                                                                                                                                                                                                                                                                                                    

Benchmark ([source](https://clj-commons.org/camel-snake-kebab/)): 
- Unmemoized: ~6.4 µs per call
- Memoized:   ~700 ns per call
                                                                                                                                                                                                                                                                                         
Ex: with 100 signal conversions per render, that's roughly **0.5 ms saved per  render cycle** — less work on the renderer hot spot.                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                
**docs: add render throttling note** 
                                                                                                                                                                                                                                                                                                                
Added a brief note to the README explaining the ~60fps render throttle so users understand how multiple cursor mutations are batched.'