### PR TITLE
feat: use snake case + compact-uuids for frontend-facing IDs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,6 +24,7 @@
   org.clojure/core.memoize            {:mvn/version "1.2.281"}
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
   ring/ring-defaults                  {:mvn/version "0.7.0"}
+  compact-uuids/compact-uuids         {:mvn/version "0.2.1"}
 
   ;; JSON
   cheshire/cheshire                   {:mvn/version "6.1.0"}

--- a/src/hyper/actions.clj
+++ b/src/hyper/actions.clj
@@ -2,7 +2,8 @@
   "Action handling for hyper applications.
 
    Actions are server-side functions triggered by client interactions."
-  (:require [taoensso.telemere :as t]))
+  (:require [compact-uuids.core :as uuid]
+            [taoensso.telemere :as t]))
 
 (defn register-action!
   "Register an action function and return its ID.
@@ -15,7 +16,7 @@
    - :as  — a human-readable name for the action, useful for testing"
   ([app-state* session-id tab-id action-fn]
    (register-action! app-state* session-id tab-id action-fn
-                     (str "action-" (java.util.UUID/randomUUID))
+                     (str "action-" (uuid/str (java.util.UUID/randomUUID)))
                      nil))
   ([app-state* session-id tab-id action-fn action-id]
    (register-action! app-state* session-id tab-id action-fn action-id nil))

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -289,7 +289,7 @@
                                                                      :hyper/router     router#}]
                                           ~@body)))
            idx#                     (if context/*action-idx* (swap! context/*action-idx* inc) (hash action-fn#))
-           action-id#               (str "a-" tab-id# "-" idx#)
+           action-id#               (str "a_" tab-id# "_" idx#)
            _#                       (actions/register-action! app-state*# session-id# tab-id# action-fn# action-id#
                                                               ~(when as-name {:as as-name}))]
        (build-action-expr action-id# '~used-params ~js))))
@@ -347,7 +347,7 @@
                                                       :query-params (or query-params {})})))
              nav-idx       (if *action-idx* (swap! *action-idx* inc) (hash nav-fn))
              action-id     (actions/register-action! app-state* session-id tab-id nav-fn
-                                                     (str "a-" tab-id "-" nav-idx))
+                                                     (str "a_" tab-id "_" nav-idx))
              escaped-title (or (utils/escape-js-string title) "")
              escaped-href  (utils/escape-js-string href)]
          {:href href

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -4,6 +4,7 @@
    Provides Ring handler creation for hyper applications."
   (:require [cheshire.core :as json]
             [clojure.string]
+            [compact-uuids.core :as uuid]
             [dev.onionpancakes.chassis.core :as c]
             [hyper.actions :as actions]
             [hyper.brotli :as br]
@@ -30,10 +31,10 @@
   (:import (java.util.concurrent Semaphore)))
 
 (defn generate-session-id []
-  (str "sess-" (java.util.UUID/randomUUID)))
+  (str "sess-" (uuid/str (java.util.UUID/randomUUID))))
 
 (defn generate-tab-id []
-  (str "tab-" (java.util.UUID/randomUUID)))
+  (str "tab_" (uuid/str (java.util.UUID/randomUUID))))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-tab renderer thread

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -27,8 +27,8 @@
           id2 (server/generate-tab-id)]
       (is (string? id1))
       (is (string? id2))
-      (is (.startsWith id1 "tab-"))
-      (is (.startsWith id2 "tab-"))
+      (is (.startsWith id1 "tab_"))
+      (is (.startsWith id2 "tab_"))
       (is (not= id1 id2)))))
 
 (deftest test-wrap-hyper-context-new-session
@@ -46,7 +46,7 @@
       (is (string? (get-in response [:cookies "hyper-session" :value])))
       (is (.startsWith (get-in response [:cookies "hyper-session" :value]) "sess-"))
       (is (.contains (:body response) "session: sess-"))
-      (is (.contains (:body response) "tab: tab-")))))
+      (is (.contains (:body response) "tab: tab_")))))
 
 (deftest test-wrap-hyper-context-existing-session
   (testing "Middleware reuses existing session from cookie"

--- a/test/hyper/test_test.clj
+++ b/test/hyper/test_test.clj
@@ -144,7 +144,7 @@
       (is (= 1 (count (:actions result))))
       (let [[k v] (first (:actions result))]
         (is (string? k))
-        (is (str/starts-with? k "a-"))
+        (is (str/starts-with? k "a_"))
         (is (fn? (:fn v)))))))
 
 (deftest test-page-signals


### PR DESCRIPTION
Adds [compact-uuids](https://github.com/tonsky/compact-uuids) library and switches frontend-facing IDs from hyphen (`-`) to underscore (`_`) separator (snake case). 
## Rationale
- **Snake case:** allow double-click selection of entire ID in browser devtools
- **Compact UUIDs:** 26 chars vs 36 chars (30% smaller), URL-safe, no ambiguous characters (0/O, 1/l/I) 
## Changes
1. **Compact UUIDs:** All UUID usages replaced with compact encoding
2. **Snake case:** Only frontend-facing IDs modified - action-id and tab-id

<img width="720" height="292" alt="Screen Recording 2026-04-16 at 21 36 14" src="https://github.com/user-attachments/assets/781dcb95-7786-49b8-b06d-0634873b487f" />

