### PR TITLE
fix(server): send SSE-friendly headers on /hyper/events

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -633,6 +633,10 @@ tab is hidden and reopening it when visible — pass `:open-when-hidden? false`:
     :open-when-hidden? false))
 ```
 
+Hyper's built-in `/hyper/events` endpoint automatically sends SSE-friendly
+headers, including `Cache-Control: no-cache, no-transform` and
+`X-Accel-Buffering: no`, to improve compatibility with reverse proxies.
+
 ## Brotli compression
 
 Hyper uses [brotli4j](https://github.com/hyperxpro/Brotli4j) to compress both

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -56,7 +56,9 @@
    ^Semaphore semaphore shutdown-renderer*]
   (let [br-out      (when compress? (br/byte-array-out-stream))
         br-stream   (when br-out (br/compress-out-stream br-out :window-size 18))
-        headers     (cond-> {"Content-Type" "text/event-stream"}
+        headers     (cond-> {"Content-Type"      "text/event-stream"
+                             "Cache-Control"     "no-cache, no-transform"
+                             "X-Accel-Buffering" "no"}
                       compress? (assoc "Content-Encoding" "br"))
         throttle-ms (long (or (get @app-state* :render-throttle-ms)
                               default-render-throttle-ms))]

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -9,7 +9,8 @@
             [hyper.state :as state]
             [hyper.watch :as watch]
             [matcher-combinators.matchers :as m]
-            [matcher-combinators.test :refer [match?]]))
+            [matcher-combinators.test :refer [match?]]
+            [org.httpkit.server :as http-kit]))
 
 (deftest test-generate-session-id
   (testing "Session ID generation"
@@ -82,6 +83,30 @@
             [:script {:src  #".*datastar.*"
                       :type "module"}]
             script)))))
+
+(deftest test-initial-sse-response-headers
+  (testing "sends the expected initial SSE response headers"
+    (doseq [[compress? expected-headers]
+            [[false {"Content-Type"      "text/event-stream"
+                     "Cache-Control"     "no-cache, no-transform"
+                     "X-Accel-Buffering" "no"}]
+             [true  {"Content-Type"      "text/event-stream"
+                     "Cache-Control"     "no-cache, no-transform"
+                     "X-Accel-Buffering" "no"
+                     "Content-Encoding"  "br"}]]]
+      (let [captured-response (atom nil)]
+        (with-redefs [http-kit/send! (fn [_channel response _close-after-send?]
+                                       (reset! captured-response response)
+                                       false)]
+          (#'server/-renderer-loop! (atom (state/init-state))
+                                    "sess-test"
+                                    "tab-test"
+                                    ::channel
+                                    compress?
+                                    (java.util.concurrent.Semaphore. 0)
+                                    (promise))
+          (is (= expected-headers
+                 (:headers @captured-response))))))))
 
 (deftest test-create-handler
   (testing "Creates a working ring handler"


### PR DESCRIPTION
## Summary

Add SSE-friendly response headers to Hyper's built-in `/hyper/events`
endpoint:

- `Cache-Control: no-cache, no-transform`
- `X-Accel-Buffering: no`

## Why

Some Hyper deployments sit behind reverse proxies such as NGINX or
OpenResty. Those proxies can buffer or transform `text/event-stream`
responses, which delays SSE delivery and can leave the browser UI stuck
in transient states even though the server-side action has already
completed.

These headers improved that behaviour in a managed hosting deployment
without requiring app-specific configuration or disabling Brotli.

## Notes

- `Cache-Control: no-cache, no-transform` is appropriate for a live SSE stream.
- `X-Accel-Buffering: no` is useful for NGINX/OpenResty and is generally harmless elsewhere.
- `Content-Type` and `Content-Encoding` remain under Hyper's control.

## Testing

Add a focused test covering the initial SSE response headers with and
without Brotli compression.
