### PR TITLE
fix: Action Not Found Race Condition

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,6 +24,7 @@
   org.clojure/core.memoize            {:mvn/version "1.2.281"}
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
   ring/ring-defaults                  {:mvn/version "0.7.0"}
+  compact-uuids/compact-uuids         {:mvn/version "0.2.1"}
 
   ;; JSON
   cheshire/cheshire                   {:mvn/version "6.1.0"}

--- a/src/hyper/actions.clj
+++ b/src/hyper/actions.clj
@@ -2,7 +2,8 @@
   "Action handling for hyper applications.
 
    Actions are server-side functions triggered by client interactions."
-  (:require [taoensso.telemere :as t]))
+  (:require [compact-uuids.core :as uuid]
+            [taoensso.telemere :as t]))
 
 (defn register-action!
   "Register an action function and return its ID.
@@ -15,7 +16,7 @@
    - :as  — a human-readable name for the action, useful for testing"
   ([app-state* session-id tab-id action-fn]
    (register-action! app-state* session-id tab-id action-fn
-                     (str "action-" (java.util.UUID/randomUUID))
+                     (str "action-" (uuid/str (java.util.UUID/randomUUID)))
                      nil))
   ([app-state* session-id tab-id action-fn action-id]
    (register-action! app-state* session-id tab-id action-fn action-id nil))

--- a/src/hyper/actions.clj
+++ b/src/hyper/actions.clj
@@ -35,20 +35,26 @@
 (defn execute-action!
   "Execute an action by ID with error handling.
    When client-params are provided they are passed to the action fn."
-  ([app-state* action-id]
-   (execute-action! app-state* action-id nil))
-  ([app-state* action-id client-params]
-   (if-let [action-data (get-in @app-state* [:actions action-id])]
-     (let [{:keys [fn]} action-data]
-       (t/catch->error! :hyper.error/execute-action
-                        (fn client-params))
-       true)
-     (do
-       (t/log! {:level :warn
-                :id    :hyper.error/action-not-found
-                :data  {:hyper/action-id action-id}
-                :msg   "Action not found"})
-       (throw (ex-info "Action not found" {:hyper/action-id action-id}))))))
+  ([app-state* tab-id action-id]
+   (execute-action! app-state* tab-id  action-id nil))
+  ([app-state* tab-id action-id client-params]
+   (let [tab-read-lock (.readLock (get-in @app-state* [:tabs tab-id :renderer :rw-lock]))]
+     (.lock tab-read-lock)
+     (try
+       (if-let [action-data (get-in @app-state* [:actions action-id])]
+         (let [{:keys [fn]} action-data]
+           (t/catch->error! :hyper.error/execute-action
+                            (fn client-params))
+           true)
+         (do
+           (t/log! {:level :warn
+                    :id    :hyper.error/action-not-found
+                    :data  {:hyper/action-id action-id}
+                    :msg   "Action not found"})
+           (throw (ex-info "Action not found" {:hyper/action-id  action-id
+                                               :hyper/action-ids (keys (get-in @app-state* [:actions]))}))))
+       (finally
+         (.unlock tab-read-lock))))))
 
 (defn cleanup-tab-actions!
   "Remove all actions for a tab."

--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -289,7 +289,7 @@
                                                                      :hyper/router     router#}]
                                           ~@body)))
            idx#                     (if context/*action-idx* (swap! context/*action-idx* inc) (hash action-fn#))
-           action-id#               (str "a-" tab-id# "-" idx#)
+           action-id#               (str "a_" tab-id# "_" idx#)
            _#                       (actions/register-action! app-state*# session-id# tab-id# action-fn# action-id#
                                                               ~(when as-name {:as as-name}))]
        (build-action-expr action-id# '~used-params ~js))))
@@ -347,7 +347,7 @@
                                                       :query-params (or query-params {})})))
              nav-idx       (if *action-idx* (swap! *action-idx* inc) (hash nav-fn))
              action-id     (actions/register-action! app-state* session-id tab-id nav-fn
-                                                     (str "a-" tab-id "-" nav-idx))
+                                                     (str "a_" tab-id "_" nav-idx))
              escaped-title (or (utils/escape-js-string title) "")
              escaped-href  (utils/escape-js-string href)]
          {:href href

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -4,6 +4,7 @@
    Provides Ring handler creation for hyper applications."
   (:require [cheshire.core :as json]
             [clojure.string]
+            [compact-uuids.core :as uuid]
             [dev.onionpancakes.chassis.core :as c]
             [hyper.actions :as actions]
             [hyper.brotli :as br]
@@ -30,10 +31,10 @@
   (:import (java.util.concurrent Semaphore)))
 
 (defn generate-session-id []
-  (str "sess-" (java.util.UUID/randomUUID)))
+  (str "sess-" (uuid/str (java.util.UUID/randomUUID))))
 
 (defn generate-tab-id []
-  (str "tab-" (java.util.UUID/randomUUID)))
+  (str "tab_" (uuid/str (java.util.UUID/randomUUID))))
 
 ;; ---------------------------------------------------------------------------
 ;; Per-tab renderer thread

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -28,7 +28,8 @@
             [ring.middleware.params :as params]
             [ring.middleware.resource :as resource]
             [taoensso.telemere :as t])
-  (:import (java.util.concurrent Semaphore)))
+  (:import (java.util.concurrent Semaphore)
+           (java.util.concurrent.locks ReentrantReadWriteLock)))
 
 (defn generate-session-id []
   (str "sess-" (uuid/str (java.util.UUID/randomUUID))))
@@ -55,12 +56,13 @@
    Exits when shutdown-renderer* is delivered."
   [app-state* session-id tab-id channel compress?
    ^Semaphore semaphore shutdown-renderer*]
-  (let [br-out      (when compress? (br/byte-array-out-stream))
-        br-stream   (when br-out (br/compress-out-stream br-out :window-size 18))
-        headers     (cond-> {"Content-Type" "text/event-stream"}
-                      compress? (assoc "Content-Encoding" "br"))
-        throttle-ms (long (or (get @app-state* :render-throttle-ms)
-                              default-render-throttle-ms))]
+  (let [br-out         (when compress? (br/byte-array-out-stream))
+        br-stream      (when br-out (br/compress-out-stream br-out :window-size 18))
+        headers        (cond-> {"Content-Type" "text/event-stream"}
+                         compress? (assoc "Content-Encoding" "br"))
+        throttle-ms    (long (or (get @app-state* :render-throttle-ms)
+                                 default-render-throttle-ms))
+        tab-write-lock (.writeLock (get-in @app-state* [:tabs tab-id :renderer :rw-lock]))]
     (try
       ;; Send the connected event as the initial SSE response (headers + body).
       (let [connected-msg (render/format-connected-event tab-id)
@@ -77,33 +79,49 @@
             (.acquire semaphore)
             (.drainPermits semaphore)
             (when-not (realized? shutdown-renderer*)
-              (let [current-signals (get-in @app-state* [:tabs tab-id :signals])
-                    sig-patches     (when (and current-signals
-                                               (not= current-signals last-sent-signals))
-                                      (signal/changed-signals last-sent-signals current-signals))
-                    sent?           (try
-                            ;; Clean slate — remove stale actions before re-rendering
-                                      (actions/cleanup-tab-actions! app-state* tab-id)
-                                      (when-let [{:keys [title head-html body-html url declared-signals]}
-                                                 (render/render-tab app-state* session-id tab-id)]
-                                        (let [head-event   (render/format-head-update title head-html)
-                                              sig-attrs    (signal/format-signal-attrs declared-signals)
-                                              div-attrs    (cond-> {:id "hyper-app"}
-                                                             url       (assoc :data-hyper-url url)
-                                                             sig-attrs (merge sig-attrs))
-                                              wrapped-html (c/html [:div div-attrs (c/raw body-html)])
-                                              body-event   (render/format-datastar-fragment wrapped-html)
-                                              sig-event    (when (seq sig-patches)
-                                                             (signal/format-patch-signals-event sig-patches))
-                                              sse-payload  (str head-event body-event sig-event)
-                                              payload      (if br-stream
-                                                             (br/compress-stream br-out br-stream sse-payload)
-                                                             sse-payload)]
-                                          (boolean (http-kit/send! channel payload false))))
-                                      (catch Throwable e
-                                        (t/error! e {:id   :hyper.error/renderer
-                                                     :data {:hyper/tab-id tab-id}})
-                                        nil))]
+              (let [[current-signals sig-patches render-tab-result]
+                    ;; 1. Lock-guarded snapshot & rendering
+                    (do
+                      (.lock tab-write-lock)
+                      (try
+                        (let [current-signals   (get-in @app-state* [:tabs tab-id :signals])
+                              sig-patches       (when (and current-signals
+                                                           (not= current-signals last-sent-signals))
+                                                  (signal/changed-signals last-sent-signals current-signals))
+                                                ;; Clean slate — remove stale actions before re-rendering
+                              _                 (actions/cleanup-tab-actions! app-state* tab-id)
+                              render-tab-result (try
+                                                  (render/render-tab app-state* session-id tab-id)
+                                                  (catch Throwable e
+                                                    (t/error! e {:id   :hyper.error/renderer
+                                                                 :data {:hyper/tab-id tab-id}})
+                                                    nil))]
+                          [current-signals sig-patches render-tab-result])
+                        (finally (.unlock tab-write-lock))))
+                    ;; 2. Format events & send payload (skip if render returned nil)
+                    sent?
+                    (try
+                      (when-let [{:keys [title head-html body-html url declared-signals]} render-tab-result]
+                        (let [head-event   (render/format-head-update title head-html)
+                              sig-attrs    (signal/format-signal-attrs declared-signals)
+                              div-attrs    (cond-> {:id "hyper-app"}
+                                             url       (assoc :data-hyper-url url)
+                                             sig-attrs (merge sig-attrs))
+                              wrapped-html (c/html [:div div-attrs (c/raw body-html)])
+                              body-event   (render/format-datastar-fragment wrapped-html)
+                              sig-event    (when (seq sig-patches)
+                                             (signal/format-patch-signals-event sig-patches))
+                              sse-payload  (str head-event body-event sig-event)
+                              payload      (if br-stream
+                                             (br/compress-stream br-out br-stream sse-payload)
+                                             sse-payload)]
+                          (boolean (http-kit/send! channel payload false))))
+                      (catch Throwable e
+                        ;; 3. Error fallback
+                        (t/error! e {:id   :hyper.error/renderer
+                                     :data {:hyper/tab-id tab-id}})
+                        nil))]
+                ;; 4. Throttle & loop continuation
                 ;; sent? is true (ok), nil (no render-fn or error), false (channel closed)
                 (when-not (false? sent?)
                   ;; Throttle: sleep so triggers during this window accumulate
@@ -145,7 +163,8 @@
                                                    semaphore shutdown-renderer*)))]
     {:trigger-render! trigger-render!
      :stop!           stop!
-     :thread          thread}))
+     :thread          thread
+     :rw-lock         (ReentrantReadWriteLock. true)}))
 
 (defn wrap-hyper-context
   "Middleware that adds session-id and tab-id to the request."
@@ -297,7 +316,7 @@
           (push-thread-bindings {#'context/*request* req-with-state
                                  #'context/*signals* signals})
           (try
-            (actions/execute-action! app-state* action-id client-params)
+            (actions/execute-action! app-state* tab-id action-id client-params)
 
             ;; 204 prevents Datastar from merging the response into signals
             {:status 204}

--- a/test/hyper/actions_test.clj
+++ b/test/hyper/actions_test.clj
@@ -3,9 +3,13 @@
             [hyper.actions :as actions]
             [hyper.state :as state]))
 
+(def initialized-state (-> (state/init-state)
+                           (assoc-in [:tabs "tab1" :renderer :rw-lock]
+                                     #java.util.concurrent.locks.ReentrantReadWriteLock[true])))
+
 (deftest register-action-test
   (testing "registers an action and returns ID"
-    (let [app-state* (atom (state/init-state))
+    (let [app-state* (atom initialized-state)
           session-id "test-session-1"
           tab-id     "test-tab-1"
           action-fn  (fn [] :executed)
@@ -18,7 +22,7 @@
       (is (fn? (get-in @app-state* [:actions action-id :fn])))))
 
   (testing "generates unique IDs"
-    (let [app-state* (atom (state/init-state))
+    (let [app-state* (atom initialized-state)
           action-fn  (fn [] :executed)
           id1        (actions/register-action! app-state* "sess1" "tab1" action-fn)
           id2        (actions/register-action! app-state* "sess1" "tab1" action-fn)]
@@ -26,30 +30,30 @@
 
 (deftest execute-action-test
   (testing "executes registered action"
-    (let [app-state* (atom (state/init-state))
+    (let [app-state* (atom initialized-state)
           executed   (atom false)
           action-fn  (fn [_] (reset! executed true))
           action-id  (actions/register-action! app-state* "sess1" "tab1" action-fn)]
-      (actions/execute-action! app-state* action-id)
+      (actions/execute-action! app-state* "tab1" action-id)
       (is @executed)))
 
   (testing "action can access closures"
-    (let [app-state*     (atom (state/init-state))
+    (let [app-state*     (atom initialized-state)
           result         (atom nil)
           captured-value 42
           action-fn      (fn [_] (reset! result captured-value))
           action-id      (actions/register-action! app-state* "sess1" "tab1" action-fn)]
-      (actions/execute-action! app-state* action-id)
+      (actions/execute-action! app-state* "tab1" action-id)
       (is (= 42 @result))))
 
   (testing "throws exception for missing action"
-    (let [app-state* (atom (state/init-state))]
+    (let [app-state* (atom initialized-state)]
       (is (thrown? Exception
-                   (actions/execute-action! app-state* "nonexistent-action"))))))
+                   (actions/execute-action! app-state* "tab1" "nonexistent-action"))))))
 
 (deftest cleanup-tab-actions-test
   (testing "removes all actions for a tab"
-    (let [app-state*  (atom (state/init-state))
+    (let [app-state*  (atom initialized-state)
           tab-id      "test-tab-cleanup"
           action-fn   (fn [_] :executed)
           action-id-1 (actions/register-action! app-state* "sess1" tab-id action-fn)
@@ -67,9 +71,9 @@
 
 (deftest test-execute-action-with-client-params
   (testing "executes action with client params passed through"
-    (let [app-state* (atom (state/init-state))
+    (let [app-state* (atom initialized-state)
           result     (atom nil)
           action-fn  (fn [params] (reset! result (:value params)))
           action-id  (actions/register-action! app-state* "sess1" "tab1" action-fn)]
-      (actions/execute-action! app-state* action-id {:value "test-value"})
+      (actions/execute-action! app-state* "tab1" action-id {:value "test-value"})
       (is (= "test-value" @result)))))

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -27,8 +27,8 @@
           id2 (server/generate-tab-id)]
       (is (string? id1))
       (is (string? id2))
-      (is (.startsWith id1 "tab-"))
-      (is (.startsWith id2 "tab-"))
+      (is (.startsWith id1 "tab_"))
+      (is (.startsWith id2 "tab_"))
       (is (not= id1 id2)))))
 
 (deftest test-wrap-hyper-context-new-session
@@ -46,7 +46,7 @@
       (is (string? (get-in response [:cookies "hyper-session" :value])))
       (is (.startsWith (get-in response [:cookies "hyper-session" :value]) "sess-"))
       (is (.contains (:body response) "session: sess-"))
-      (is (.contains (:body response) "tab: tab-")))))
+      (is (.contains (:body response) "tab: tab_")))))
 
 (deftest test-wrap-hyper-context-existing-session
   (testing "Middleware reuses existing session from cookie"

--- a/test/hyper/test_test.clj
+++ b/test/hyper/test_test.clj
@@ -144,7 +144,7 @@
       (is (= 1 (count (:actions result))))
       (let [[k v] (first (:actions result))]
         (is (string? k))
-        (is (str/starts-with? k "a-"))
+        (is (str/starts-with? k "a_"))
         (is (fn? (:fn v)))))))
 
 (deftest test-page-signals


### PR DESCRIPTION
This fix builds on PR #34, which helped identify the root cause. 
Originally, I encountered the problem when an action received CustomEvents from a third-party JS component (similar to this [datastar example](https://data-star.dev/examples/sortable)) "concurrently" with another action trigger.

## How to reproduce
Load `example.app` ns and start typing chars fast until get HTTP 500. 
<img width="1933" height="248" alt="Screenshot 2026-04-19 at 15 06 26" src="https://github.com/user-attachments/assets/30c6750d-8047-4d98-8b03-ac35d4fa78de" />


## Symptom

Intermittent errors:
```
ERROR hyper.server Action not found 
{:hyper/action-id "a_tab_e62e9fkbq0jyza5sepz82j50ex_1", :hyper/action-ids {}}
```

The `:actions` map was completely empty — despite actions being registered on every render.

---

## Root Cause: The Cleanup Gap

The render loop in `server.clj` performed two operations sequentially:

```clojure
;; server.clj -renderer-loop! (BEFORE fix)
(actions/cleanup-tab-actions! app-state* tab-id)   ; Step A: wipe ALL actions
(render/render-tab app-state* session-id tab-id)    ; Step B: re-register actions
```

Between Step A and Step B, `:actions` is `{}`. This gap lasts ~1-50ms depending on render complexity.

---

## The Broken Flow (Race Condition Timeline)

```
Time    Render Thread                          Action Handler Thread
────    ─────────────                          ─────────────────────
T0      cleanup-tab-actions! → :actions = {}
T1                                             User clicks button
T2                                             HTTP POST arrives: action-id = "a_tab_..._1"
T3                                             (get-in @app-state* [:actions id]) → nil!
T4      render-tab starts registering actions  ERROR: "Action not found"
T5      render-tab finishes, :actions has data
T6      send! SSE payload to client
```

The action handler's lookup at T3 happens during the gap — the action existed at T0 (from the previous render), was wiped at T0, and hasn't been re-registered yet at T4.

---

## Why Simpler Fixes Don't Work

| Approach | Why It Fails |
|----------|-------------|
| **Remove cleanup** | Old actions execute mid-render, mutating state while render reads it → inconsistent HTML (part rendered with old state, part with new) |
| **Graceful "not found"** | Silently drops the action → state mutation is lost → app logic breaks |
| **Spin-wait loop** | Wastes CPU cycles polling — violates the semaphore pattern already used for efficient thread parking |
| **Move lookup after cleanup** | Same race — the gap still exists between cleanup and re-registration |

---

## The Correct Fix: ReentrantReadWriteLock (FIFO)

### Why RwLock specifically:

1. **Read lock is shared** — multiple actions execute concurrently (no throughput loss during normal operation)
2. **Write lock is exclusive** — blocks ALL actions during cleanup+render (no mid-render mutation)
3. **FIFO mode** — prevents render starvation under heavy action load (render gets its turn in queue)
4. **Zero CPU waste** — threads park while waiting (same efficiency as the existing semaphore pattern)

The lock must cover the **entire** action lifecycle — lookup AND execution. If the lookup happens outside the lock, the race still exists.

### The Correct Flow (With RwLock)

```
Time    Render Thread (write lock)               Action Handler Thread (read lock)
────    ────────────────────────                 ─────────────────────────────────
T0      .lock writeLock
T1      cleanup-tab-actions! → :actions = {}     (.lock readLock) ← BLOCKED by write lock
T2      render-tab registers new actions         (still waiting...)
T3      .unlock writeLock                        (acquires read lock)
T4      send! SSE payload                        (get-in @app-state* [:actions id]) → found! ✓
T5                                               (fn client-params) → executes ✓
T6                                               .unlock readLock
```

The action handler blocks at T1 until the render completes at T3. By then, new actions are registered and the lookup succeeds.

---

## Files Changed

| File | Change                                                                                                                                       |
|------|----------------------------------------------------------------------------------------------------------------------------------------------|
| `hyper/server.clj` | Added `ReentrantReadWriteLock` import; created lock per tab in `-start-renderer!`; wrapped cleanup+render in write lock in `-renderer-loop!` |
| `hyper/actions.clj` | Acquire read lock, then perform lookup + execution inside the lock                                                                           |

---

## Key Design Decisions

1. **Release write lock after render, before send** — Minimizes lock hold time; send! doesn't touch app-state anyway
2. **FIFO fairness mode** — Prevents render starvation under heavy action load
3. **Lock covers lookup + execution** — The critical fix; prevents the race at the source