### PR TITLE
feat: :html-attrs option on create-handler

### DIFF
--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -494,6 +494,8 @@
    - :app-state         — Atom for application state (default: fresh atom)
    - :datastar-script   - Override of the default datastar script tag (as Hiccup) or nil to suppress
    - :head              — Hiccup nodes appended to the HTML <head>, or (fn [req] ...) -> hiccup
+   - :html-attrs        — Map of attributes merged onto the root <html> element
+                          (e.g. {:lang \"en\"}).  Defaults to none.
    - :base-path         — URL path prefix for reverse-proxy deployments where the app is served
                           under a subfolder (e.g. \"/my-app\"). When set, all internal hyper
                           endpoints (/hyper/events, /hyper/actions, /hyper/navigate) are mounted
@@ -553,13 +555,14 @@
      (def app (start! handler {:port 3000}))
      ;; Later...
      (stop! app)"
-  [routes & {:keys [app-state head static-resources static-dir watches
+  [routes & {:keys [app-state head html-attrs static-resources static-dir watches
                     datastar-script base-path middleware render-middleware
                     render-error]
              :or   {app-state       (atom (state/init-state))
                     datastar-script server/default-datastar-script}}]
   (server/create-handler routes app-state
                          (cond-> {:head              head
+                                  :html-attrs        html-attrs
                                   :datastar-script   datastar-script
                                   :static-resources  static-resources
                                   :static-dir        static-dir

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -515,9 +515,12 @@
    re-resolution, title/head resolution).
 
    Options:
-   - :datastar-script - Hiccup content for Datastar script added to document head, or nil."
-  [app-state* {:keys [datastar-script open-when-hidden? base-path] :or {open-when-hidden? true
-                                                                        base-path         ""}}]
+   - :datastar-script - Hiccup content for Datastar script added to document head, or nil.
+   - :html-attrs      - Map of attributes merged onto the root <html> element
+                        (e.g. {:lang \"en\"}).  Defaults to none."
+  [app-state* {:keys [datastar-script html-attrs open-when-hidden? base-path]
+               :or   {open-when-hidden? true
+                      base-path         ""}}]
   (fn [render-fn]
     (fn [req]
       (let [tab-id     (:hyper/tab-id req)
@@ -540,7 +543,7 @@
                                                                          sig-attrs (merge sig-attrs))
                   html                                                 (c/html
                                                                          [c/doctype-html5
-                                                                          [:html
+                                                                          [:html (or html-attrs {})
                                                                            [:head
                                                                             [:meta {:charset "UTF-8"}]
                                                                             [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
@@ -679,6 +682,8 @@
    Options:
    - :head              Hiccup nodes appended to the <head> (e.g. stylesheet <link>),
                         or (fn [req] ...) -> hiccup nodes appended to the <head>
+   - :html-attrs        Map of attributes merged onto the root <html> element
+                        (e.g. {:lang \"en\"}).  Defaults to none.
    - :datastar-script   Hiccup nodes for the Datastar script (or nil to suppress)
    - :open-when-hidden? Keep the SSE connection open when the browser tab is hidden
                         (default true). When false, Datastar closes the connection

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -151,6 +151,32 @@
       (is (.contains (:body response) "data-hyper-head")
           "Head elements are marked for SSE management")))
 
+  (testing "Allows :html-attrs to be set on root <html>"
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          handler    (server/create-handler routes app-state*
+                                            {:html-attrs {:lang     "en"
+                                                          :data-app "demo"}})
+          response   (handler {:uri "/" :request-method :get})
+          html       (:body response)]
+      (is (= 200 (:status response)))
+      (is (.contains html "lang=\"en\"")
+          "Root <html> carries the :lang attribute")
+      (is (.contains html "data-app=\"demo\"")
+          "Root <html> carries the :data-app attribute")))
+
+  (testing ":html-attrs defaults to none (no attributes on <html>)"
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div "Home"])}]]
+          handler    (server/create-handler routes app-state* {})
+          response   (handler {:uri "/" :request-method :get})
+          html       (:body response)]
+      (is (= 200 (:status response)))
+      (is (.contains html "<html>")
+          "Root <html> renders bare when no :html-attrs provided")))
+
   (testing "Datastar script override"
     (let [app-state* (atom (state/init-state))
           routes     [["/" {:name :home


### PR DESCRIPTION
## Summary

Add a small `:html-attrs` map option on `create-handler` that is
merged onto the root `<html>` element of every page. Threads through
`core/create-handler` → `server/create-handler` → `server/page-handler`,
which destructures and applies it as `[:html (or html-attrs {}) ...]`.
Defaults to none.

Primary use case is `:lang` for accessibility / SEO without dropping
to a custom page-handler:

```clojure
(h/create-handler #'routes :html-attrs {:lang "en"})
```

Other attributes (`:dir`, `:data-*`) work the same way.

## Test plan

Two new `(testing ...)` blocks under `test-create-handler` in
`hyper.server-test`:

- Populated `:html-attrs` → asserts `lang="en"` and `data-app="demo"`
  appear on the root element.
- Omitted `:html-attrs` → asserts the rendered HTML still contains a
  bare `<html>` element.

`clojure -M:test --focus :unit` is green (194 tests / 886 assertions
on this branch).

🤖 Generated with [eca](https://eca.dev)
