### PR TITLE
feat: :hiccup-transform option on create-handler

### DIFF
--- a/src/hyper/core.clj
+++ b/src/hyper/core.clj
@@ -516,6 +516,10 @@
                           Each is (fn [handler] (fn [req] ...)), identical to Ring
                           middleware.  Applied on both initial page loads and SSE
                           re-renders.  Per-route :render-middleware wraps inside these.
+   - :hiccup-transform  — (fn [hiccup] hiccup) applied to body and head hiccup before
+                          Chassis serialization.  Useful for expanding component systems
+                          (e.g. lambdaisland/ornament defstyled components) into plain
+                          keyword-first hiccup vectors that Chassis can serialize.
    - :render-error      — Function `(fn [error req] -> hiccup)` rendered when a
                           view's render-fn throws.  May be a Var to pick up
                           redefinitions without restarting the server.  Defaults
@@ -555,7 +559,7 @@
      (stop! app)"
   [routes & {:keys [app-state head static-resources static-dir watches
                     datastar-script base-path middleware render-middleware
-                    render-error]
+                    render-error hiccup-transform]
              :or   {app-state       (atom (state/init-state))
                     datastar-script server/default-datastar-script}}]
   (server/create-handler routes app-state
@@ -566,7 +570,8 @@
                                   :watches           watches
                                   :base-path         base-path
                                   :middleware        middleware
-                                  :render-middleware render-middleware}
+                                  :render-middleware render-middleware
+                                  :hiccup-transform  hiccup-transform}
                            ;; Only forward when supplied so server-level
                            ;; default (`render.error/minimal`) applies otherwise.
                            render-error (assoc :render-error render-error))))

--- a/src/hyper/render.clj
+++ b/src/hyper/render.clj
@@ -305,15 +305,19 @@
              ;; register actions during realization.  We must read
              ;; *registered-action-ids* AFTER serialization so the
              ;; accumulator captures every action the render produced.
-             (let [body         (unwrap-body raw-body)
+             (let [transform    (get @app-state* :hiccup-transform)
+                   raw-head     (some-> (routes/resolve-head (get @app-state* :head) req)
+                                        mark-head-elements)
+                   body         (cond-> (unwrap-body raw-body)
+                                  transform transform)
+                   head         (cond-> raw-head
+                                  (and transform raw-head) transform)
                    body-html    (if (vector? body)
                                   (c/html body)
                                   (apply str (map c/html body)))
                    title-spec   (when (and (seq route-index) route)
                                   (routes/find-route-title route-index (:name route)))
                    title        (routes/resolve-title title-spec req)
-                   head         (some-> (routes/resolve-head (get @app-state* :head) req)
-                                        mark-head-elements)
                    declared     @context/*declared-signals*
                    action-ids   @context/*registered-action-ids*
                    reactive-ids @context/*registered-reactive-ids*]

--- a/src/hyper/server.clj
+++ b/src/hyper/server.clj
@@ -712,12 +712,19 @@
                         `hyper.render.error/minimal` (generic, production-safe).
                         Use `hyper.render.error/explain` in development to see
                         the message, ex-data, and full stack trace.
+   - :hiccup-transform  (fn [hiccup] hiccup) applied to body and head hiccup
+                        before Chassis serialization.  Useful for expanding
+                        component systems (e.g. lambdaisland/ornament defstyled
+                        components) into plain keyword-first hiccup vectors that
+                        Chassis can serialize.  Runs on initial page loads and
+                        every SSE re-render.
 
    Routes should use :get handlers that return hiccup (Chassis vectors).
    Hyper will wrap them to provide full HTML responses and SSE connections."
   ([routes app-state*]
    (create-handler routes app-state* {:datastar-script (default-datastar-script)}))
-  ([routes app-state* {:keys [watches head base-path middleware render-middleware render-error]
+  ([routes app-state* {:keys [watches head base-path middleware render-middleware render-error
+                              hiccup-transform]
                        :or   {render-error render.error/minimal}
                        :as   opts}]
    (let [base-path       (or base-path "")
@@ -732,13 +739,16 @@
          ;; Store base-path so actions and navigate can reference prefixed URLs.
          ;; :render-error is stored as-is (fn or Var); render-tab invokes it
          ;; via IFn so a Var picks up redefinitions on each call.
+         ;; :hiccup-transform is read by render-tab to expand component
+         ;; systems (e.g. ornament defstyled) before Chassis serialization.
          _               (swap! app-state* assoc
                                 :routes-source routes
                                 :global-watches (vec watches)
                                 :head head
                                 :base-path base-path
                                 :render-middleware (vec render-middleware)
-                                :render-error render-error)
+                                :render-error render-error
+                                :hiccup-transform hiccup-transform)
          initial-routes  (if (var? routes) @routes routes)
          initial-handler (build-ring-handler initial-routes app-state* page-wrapper system-routes)
          handler         (if (var? routes)

--- a/test/hyper/server_test.clj
+++ b/test/hyper/server_test.clj
@@ -151,6 +151,43 @@
       (is (.contains (:body response) "data-hyper-head")
           "Head elements are marked for SSE management")))
 
+  (testing "Allows :hiccup-transform to expand custom hiccup before serialization"
+    ;; Simulate a tiny component system: a vector whose first element is
+    ;; ::comp is "expanded" into a real hiccup vector.  Without
+    ;; :hiccup-transform, Chassis would not know how to render ::comp;
+    ;; the transform converts it to [:span ...] before serialization.
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [::greeting "world"])}]]
+          expand     (fn expand [form]
+                       (cond
+                         (and (vector? form) (= ::greeting (first form)))
+                         (into [:span.greeting "Hello, "] (rest form))
+
+                         (vector? form) (mapv expand form)
+                         (seq? form)    (map expand form)
+                         :else          form))
+          handler    (server/create-handler routes app-state*
+                                            {:hiccup-transform expand})
+          response   (handler {:uri "/" :request-method :get})
+          html       (:body response)]
+      (is (= 200 (:status response)))
+      (is (.contains html "class=\"greeting\"")
+          "Custom ::greeting node was expanded to [:span.greeting ...]")
+      (is (.contains html "Hello, world")
+          "Children of the custom node survived the transform")))
+
+  (testing ":hiccup-transform defaults to nil (body is rendered unchanged)"
+    (let [app-state* (atom (state/init-state))
+          routes     [["/" {:name :home
+                            :get  (fn [_req] [:div.untouched "plain"])}]]
+          handler    (server/create-handler routes app-state* {})
+          response   (handler {:uri "/" :request-method :get})
+          html       (:body response)]
+      (is (= 200 (:status response)))
+      (is (.contains html "class=\"untouched\""))
+      (is (.contains html "plain"))))
+
   (testing "Datastar script override"
     (let [app-state* (atom (state/init-state))
           routes     [["/" {:name :home


### PR DESCRIPTION
## Summary

Add an optional `:hiccup-transform` `(fn [hiccup] hiccup)` to
`create-handler`.  The function is applied to body and head hiccup
just before Chassis serializes them, on both initial page loads and
every SSE re-render.

Primary motivation: component systems whose elements are not plain
keyword-first vectors.  Chassis only renders `[:tag ...]` (and the
namespaced-keyword alias mechanism); integrations such as
`lambdaisland/ornament` produce IFn-based styled components that need
to be expanded into hiccup *before* Chassis sees them.  Without a
transform hook, every callsite has to wrap its body manually.

```clojure
(h/create-handler #'routes
  :hiccup-transform my.ornament/expand-styled)
```

Implementation:

- `core/create-handler` accepts `:hiccup-transform` and forwards it
  in the opts map.
- `server/create-handler` destructures it and stashes it on app-state
  via the existing `swap!` block.
- `render/render-tab` reads it from app-state and applies it to
  `body` and `head` (when present) before `c/html`.  Same call site
  for initial loads and SSE re-renders.

Defaults to `nil`, in which case body/head are passed through unchanged.

## Test plan

Two new `(testing ...)` blocks under `test-create-handler` in
`hyper.server-test`:

- A tiny custom-tag expander rewrites `[::greeting "world"]` into
  `[:span.greeting "Hello, " "world"]` and asserts the expansion is
  visible in the rendered HTML.
- Asserts that omitting `:hiccup-transform` leaves the body untouched.

`clojure -M:test --focus :unit` is green (194 tests / 887 assertions
on this branch).

🤖 Generated with [eca](https://eca.dev)
